### PR TITLE
トップページにYoutube動画の表示

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -92,3 +92,18 @@ body {
 body {
 	background-color:#EEEEEE	;		/*ページ全体の背景色*/
 }
+
+// Youtube動画
+.youtube {
+  position: relative;
+     padding-bottom: 56.25%; /*アスペクト比 16:9の場合の縦幅*/
+     height: 0;
+     overflow: hidden;
+}
+.youtube iframe {
+  position: absolute;
+     top: 0;
+     left: 0;
+     width: 100%;
+     height: 100%;
+}

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -4,7 +4,7 @@ class HomesController < ApplicationController
   require 'google/apis/youtube_v3'
   require 'active_support/all'
   
-  GOOGLE_API_KEY = "AIzaSyBuG9WwRiGjDRgByGPLpjvDNdJOjm89eqk"
+  GOOGLE_API_KEY = "AIzaSyA3Z2MVyChn2wavCxawDBDhkK8yMup8its"
 
   def find_videos(keyword, after: 1.months.ago, before: Time.now)
     service = Google::Apis::YoutubeV3::YouTubeService.new

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -20,7 +20,9 @@ class HomesController < ApplicationController
       published_after: after.iso8601,
       published_before: before.iso8601
     }
+
     service.list_searches(:snippet, opt)
+
   end
 
   # 1ページの表示数
@@ -32,7 +34,8 @@ class HomesController < ApplicationController
       @posts = @q.result.page(params[:page]).per(PER_PAGE)
       
       # 動画を取得
-      @youtube_data = find_videos('Mリーグ')
+      @youtube_data = find_videos('M.LEAGUE [プロ麻雀リーグ]')
+  
   end
   
 end

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,25 +1,38 @@
 class HomesController < ApplicationController
   
+  # YoutubeAPIでMリーグの動画を表示
+  require 'google/apis/youtube_v3'
+  require 'active_support/all'
+  
+  GOOGLE_API_KEY = "AIzaSyBuG9WwRiGjDRgByGPLpjvDNdJOjm89eqk"
+
+  def find_videos(keyword, after: 1.months.ago, before: Time.now)
+    service = Google::Apis::YoutubeV3::YouTubeService.new
+    service.key = GOOGLE_API_KEY
+
+    next_page_token = nil
+    opt = {
+      q: keyword,
+      type: 'video',
+      max_results: 2,
+      order: :date,
+      page_token: next_page_token,
+      published_after: after.iso8601,
+      published_before: before.iso8601
+    }
+    service.list_searches(:snippet, opt)
+  end
+
   # 1ページの表示数
   PER_PAGE = 9
 
   def index
-    if user_signed_in?
-            
-      # 投稿一覧を表示させるために全取得
-      # @posts = current_user.posts.all
-      
-      # 投稿一覧画面で新規投稿を行うので、formのパラメータ用にPostオブジェクトを取得  
-      # @post = current_user.posts.new  
-
+      # ページネーション
       @q = Post.ransack(params[:q])
       @posts = @q.result.page(params[:page]).per(PER_PAGE)
-    
-    else
       
-      redirect_to new_user_session_path
-
-    end
+      # 動画を取得
+      @youtube_data = find_videos('Mリーグ')
   end
   
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,8 +1,9 @@
 class PostsController < ApplicationController
+  
     def index
 
       @post = Post.new
-    
+      
     end
     
       def show

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -30,14 +30,22 @@
 
 <div id="rateYo"></div>
 
-<div class="mx-auto" style="width: 200px;">
+<!-- ページネーション -->
+<div class="mx-auto" style="width: 200px;margin-bottom:150px;">
   <%= paginate @posts %>
 </div>
 
-<% @youtube_data.items.each do |item| %>
-  <% snippet = item.snippet %>
-  <p><%= snippet.title %></p>
-  <p><%= snippet.published_at%></p>
-  <p><%= snippet.channel_title %></p>
-  <div><iframe width="560" height="315" src="https://www.youtube.com/embed/<%= item.id.video_id %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
-<% end %>
+<!-- youtube動画 -->
+<div class="container">
+  <h3>Mリーグ最新動画</h3>
+    <div class="border rounded" style="padding:50px;background-color:white;">
+      <% @youtube_data.items.each do |item| %>
+        <% snippet = item.snippet %>
+        <!--<p><%= snippet.published_at%></p>-->
+          <div class="youtube">
+            <iframe src="https://www.youtube.com/embed/<%= item.id.video_id %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+          </div>
+        <h4 style="padding:30px;"><%= snippet.title %></h4>
+      <% end %>
+    </div>
+</div>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -37,6 +37,7 @@
 <% @youtube_data.items.each do |item| %>
   <% snippet = item.snippet %>
   <p><%= snippet.title %></p>
-  <p><%= snippet.published_at %><%= snippet.channel_title %></p>
+  <p><%= snippet.published_at%></p>
+  <p><%= snippet.channel_title %></p>
   <div><iframe width="560" height="315" src="https://www.youtube.com/embed/<%= item.id.video_id %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
 <% end %>

--- a/app/views/homes/index.html.erb
+++ b/app/views/homes/index.html.erb
@@ -33,3 +33,10 @@
 <div class="mx-auto" style="width: 200px;">
   <%= paginate @posts %>
 </div>
+
+<% @youtube_data.items.each do |item| %>
+  <% snippet = item.snippet %>
+  <p><%= snippet.title %></p>
+  <p><%= snippet.published_at %><%= snippet.channel_title %></p>
+  <div><iframe width="560" height="315" src="https://www.youtube.com/embed/<%= item.id.video_id %>" frameborder="0" allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe></div>
+<% end %>


### PR DESCRIPTION
##実装内容
 -  YoutubeAPIを用いてMリーグの動画を取得
 - トップページに表示
 - 最新の動画を２つ
